### PR TITLE
Rewrite of editor plugin to support TinyMCE v6 APIs

### DIFF
--- a/src/TinyMce/ClientResources/editor_plugin.js
+++ b/src/TinyMce/ClientResources/editor_plugin.js
@@ -4,48 +4,42 @@ var tinymce = tinymce || {};
 var currentUrl = location.href;
 
 tinymce.PluginManager.add("getaepiimageshop", function (ed, url) {
-    var imageNode;
-
-    // Register commands
-    ed.addCommand('mcegetaepiimageshop', function () {
-
-        try {
-            var baseUrl = location.protocol + '//' + location.host;
-            var dialogUrl = baseUrl + "/imageshoptinymce/insertimage/?tinyMce=True";
-            console.log("Url for dialog: " + dialogUrl);
-
-            if (ed.selection !== null && ed.selection.getNode() !== null && ed.selection.getNode().src !== null)
-                dialogUrl += "&image=" + encodeURIComponent(ed.selection.getNode().src);
-
-            ed.windowManager.open({
-                file: dialogUrl,
-                width: 950,
-                height: 650,
-                scrollbars: 1,
-                inline: 1
-            }, {
-                plugin_url: url
-            });
-        } catch (error) {
-            console.log("Error running command mcegetaepiimageshop: " + error);
-        }
-    });
 
     // Register buttons
-    ed.addButton("getaepiimageshop", {
+    ed.ui.registry.addToggleButton("getaepiimageshop", {
         title: "Insert/Upload Imageshop Image",
-        cmd: "mcegetaepiimageshop",
-        image: url + "/images/icon.gif",
-        onPostRender: function () {
-            // Add a node change handler, selects the button in the UI when a image is selected
-            ed.on("NodeChange", function (e) {
-                //Prevent tool from being activated as objects represented as images.
-                var isWebShopImage = e.element.tagName === "IMG" && (ed.dom.getAttrib(e.element, "class").indexOf("ScrImageshopImage") > -1 || ed.dom.getAttrib(e.element, "class").indexOf("mceItem") === -1);
-                this.active(isWebShopImage);
+        text: "",
+        icon: url + "/images/icon.gif",
+        onSetup: (buttonApi) => {
 
-                //Set or reset imageNode to the node cause Image Editor command enabled
-                imageNode = isWebShopImage ? e.element : null;
-            }.bind(this));
+            // Add a node change handler, selects the button in the UI when a image is selected
+            const editorEventCallback = (e) => {
+                var isWebShopImage = e.element.tagName === "IMG" && (ed.dom.getAttrib(e.element, "class").indexOf("ScrImageshopImage") > -1 || ed.dom.getAttrib(e.element, "class").indexOf("mceItem") === -1);
+                buttonApi.setActive(isWebShopImage);
+            };
+            ed.on('NodeChange', editorEventCallback);
+
+            // onSetup should always return the unbind handlers
+            return () => editor.off('NodeChange', editorEventCallback);
+
+        },
+        onAction: function () {
+            try {
+                var baseUrl = location.protocol + '//' + location.host;
+                var dialogUrl = baseUrl + "/imageshoptinymce/insertimage/?tinyMce=True";
+                console.log("Url for dialog: " + dialogUrl);
+
+                if (ed.selection !== null && ed.selection.getNode() !== null && ed.selection.getNode().src !== null)
+                    dialogUrl += "&image=" + encodeURIComponent(ed.selection.getNode().src);
+
+                tinymce.activeEditor.windowManager.openUrl({
+                    title: 'ImageShop',
+                    url: dialogUrl
+                });
+
+            } catch (error) {
+                console.log("Error setting up button action: " + error);
+            }
         }
     });
 


### PR DESCRIPTION
Since Optimizely upgraded their Nuget package for TinyMCE to v.4.0.0, they introduced a new version of TinyMCE (v6) which has a lot of breaking changes to the API. 
This PR modifies editor_plugin.js to support the new version. 