### PR TITLE
Alt text for Tinymce

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ See configuration section GetaEpiImageshop in appSettings.json for examples.
 ![ScreenShot](https://raw.githubusercontent.com/screentek/Optimizely/master/docs/imageshop-tinymce-plugin.png)
 
 ## Changelog
+
+- **v1.1.0**: Images inserted to TinyMCE now contains additional data. Popup window for TinyMCE no longer automatically closing after a few seconds.
 - **v1.0.41**: Bugfixes: Settings can now be read from appsettings.<environment>.json files with fallback on appsettings.json, In tinymce we have added increased support for linux systems (case sensitivity for files), added additional close button to tinymce popup window, fixed bug where the source of the popup window sometimes was undefined.
 - **v1.0.40**: Bugfixes: Images now display alt-text correctly and added some useful comments on view files for models.
 - **v1.0.39**: Updated plugin to support TinyMCE v5 and newer. Bugfix: Missing images are now included when building your project.

--- a/src/TinyMce/ClientResources/InsertImage.cshtml
+++ b/src/TinyMce/ClientResources/InsertImage.cshtml
@@ -54,10 +54,50 @@
             }
         }
 
+        function isNumeric(num) {
+            return !isNaN(num);
+        }
+
         function listener(event) {
             var eventdata = event.data.split(";");
-            console.log(eventdata);
-            insert(eventdata[0], eventdata[1], eventdata[2], eventdata[3]);
+            //file, title, width, height, alignment = null, descriptionstring = null
+
+            var file = eventdata[0];
+            var title = eventdata[1];
+            var width = eventdata[2];
+            var height = eventdata[3];
+            var alignment = eventdata[4];
+            var descriptionString = eventdata[4];
+
+            console.log("Checking content:");
+            console.log(file);
+            console.log(title);
+            console.log(width);
+            console.log(height);
+            console.log(alignment);
+            console.log(descriptionString);
+
+            console.log("Checking typeof:");
+            console.log(typeof (file));
+            console.log(typeof (title));
+            console.log(typeof (width));
+            console.log(typeof (height));
+            console.log(typeof (alignment));
+            console.log(typeof (descriptionString));
+
+            console.log("Checking int values:");
+            console.log(isNumeric(file));
+            console.log(isNumeric(title));
+            console.log(isNumeric(width));
+            console.log(isNumeric(height));
+            console.log(isNumeric(alignment));
+            console.log(isNumeric(descriptionString));
+
+            if (file !== undefined && title !== undefined && isNumeric(width) && isNumeric(height)) {
+                insert(file, title, width, height, alignment, descriptionString);
+            }
+            console.log("Tried to return invalid data..");
+            //insert(file, title, width, height, alignment, descriptionstring);
         }
 
         $(function () {

--- a/src/TinyMce/ClientResources/InsertImage.cshtml
+++ b/src/TinyMce/ClientResources/InsertImage.cshtml
@@ -69,35 +69,9 @@
             var alignment = eventdata[4];
             var descriptionString = eventdata[4];
 
-            console.log("Checking content:");
-            console.log(file);
-            console.log(title);
-            console.log(width);
-            console.log(height);
-            console.log(alignment);
-            console.log(descriptionString);
-
-            console.log("Checking typeof:");
-            console.log(typeof (file));
-            console.log(typeof (title));
-            console.log(typeof (width));
-            console.log(typeof (height));
-            console.log(typeof (alignment));
-            console.log(typeof (descriptionString));
-
-            console.log("Checking int values:");
-            console.log(isNumeric(file));
-            console.log(isNumeric(title));
-            console.log(isNumeric(width));
-            console.log(isNumeric(height));
-            console.log(isNumeric(alignment));
-            console.log(isNumeric(descriptionString));
-
-            if (file !== undefined && title !== undefined && isNumeric(width) && isNumeric(height)) {
+            if (file !== undefined && isNumeric(width) && isNumeric(height)) {
                 insert(file, title, width, height, alignment, descriptionString);
             }
-            console.log("Tried to return invalid data..");
-            //insert(file, title, width, height, alignment, descriptionstring);
         }
 
         $(function () {

--- a/src/TinyMce/ClientResources/InsertImage.cshtml
+++ b/src/TinyMce/ClientResources/InsertImage.cshtml
@@ -67,7 +67,7 @@
             var width = eventdata[2];
             var height = eventdata[3];
             var alignment = eventdata[4];
-            var descriptionString = eventdata[4];
+            var descriptionString = eventdata[5];
 
             if (file !== undefined && isNumeric(width) && isNumeric(height)) {
                 insert(file, title, width, height, alignment, descriptionString);

--- a/src/TinyMce/ClientResources/InsertImage.cshtml
+++ b/src/TinyMce/ClientResources/InsertImage.cshtml
@@ -57,7 +57,7 @@
         function listener(event) {
             var eventdata = event.data.split(";");
             console.log(eventdata);
-            insert(eventdata[0], eventdata[1], eventdata[2], eventdata[3]);
+            insert(eventdata[0], eventdata[1], eventdata[2], eventdata[3], eventdata[4], eventdata[5]);
         }
 
         $(function () {

--- a/src/TinyMce/ClientResources/InsertImage.cshtml
+++ b/src/TinyMce/ClientResources/InsertImage.cshtml
@@ -92,42 +92,72 @@
 
         });
 
-        function insert(file, title, width, height) {
+        function insert(file, title, width, height, alignment = null, descriptionstring = null) {
+
             var ed = tinyMCEPopup.editor, dom = ed.dom;
 
             var imgobj;
+            var descriptionobject = null;
 
-            if (height && height != 0) {
-
+            if (descriptionstring != null) {
+                descriptionobject = JSON.parse(descriptionstring);
                 imgobj = {
                     src: file,
-                    alt: title,
-                    title: title,
-                    border: 0,
-                    width: width,
-                    height: height
-                };
+                    alt: descriptionobject.Description ? descriptionobject.Description : descriptionobject.Name,
+                    border: null,
+                    'data-credits': descriptionobject.Credits,
+                    'data-authorName': descriptionobject.AuthorName,
+                    'data-tags': descriptionobject.Tags,
+                    'data-name': descriptionobject.Name,
+                    'data-description': descriptionobject.Description
+
+                }
+                if (height != 0) {
+                    imgobj.height = height;
+                }
+                if (width != 0) {
+                    imgobj.width = width;
+                }
             }
-            else if (width && width != 0) {
-                imgobj = {
-                    src: file,
-                    alt: title,
-                    title: title,
-                    border: 0,
-                    width: width
-                };
-            } else {
-                imgobj = {
-                    src: file,
-                    alt: title,
-                    title: title,
-                    border: 0
-                };
+            else {
+
+                if (height != 0) {
+
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0,
+                        width: width,
+                        height: height
+                    };
+                }
+                else if (width != 0) {
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0,
+                        width: width
+                    };
+                } else {
+                    imgobj = {
+                        src: file,
+                        alt: title,
+                        title: title,
+                        border: 0
+                    };
+                }
+            }
+
+            if (alignment != null) {
+                imgobj["style"] = "float: " + alignment;
             }
 
             tinyMCEPopup.execCommand('mceInsertContent', false, dom.createHTML('img', imgobj));
 
             tinyMCEPopup.close();
+
         }
 
     </script>

--- a/src/TinyMce/ClientResources/editor_plugin.js
+++ b/src/TinyMce/ClientResources/editor_plugin.js
@@ -25,7 +25,7 @@ tinymce.PluginManager.add("getaepiimageshop", function (ed, url) {
     var buttonText = "";
     var buttonIcon = url + "/images/icon.png";
     var controllerPath = "/imageshoptinymce/insertimage/";
-    var dialogUrl = hostUrl + controllerPath + "?tinyMce=True";
+    var dialogUrl = hostUrl + controllerPath + "?TINYMCE=true&TINYMCEEXTENDED=true";
 
     if (tinymce.majorVersion >= 5) {
         // Register icon for Imageshop


### PR DESCRIPTION
Use new option TINYMCEEXTENDED=true to use description with fallback to name as alt text and add data attributes for credits, authorName, tags, name, description. Title will not be set. This is a change from before, when credits was used for alt text and title, and no data attributes was set.
Fix error in parameters for tinymce (spelled with wrong capitalization).