### PR TITLE
Override configs from Environment variables

### DIFF
--- a/src/Configuration/ImageshopConfigurationSection.cs
+++ b/src/Configuration/ImageshopConfigurationSection.cs
@@ -36,6 +36,7 @@ namespace Imageshop.Optimizely.Plugin.Configuration
 
             builder.AddJsonFile("appSettings.json", optional: true);
             builder.AddJsonFile("appsettings.json", optional: true);
+            builder.AddEnvironmentVariables();
 
             var configuration = builder.Build();
             var settingsSection = configuration.GetSection("ImageshopOptimizelyPlugin:Settings");


### PR DESCRIPTION
This fixes the issue where configuration needs to be overridden by Environment variables. Now, when deploying an application (which uses this plugin) to cloud env. (e.g. Azure), it's possible to override configuration settings via e.g. Azure AppService configs. As a result we can now enable all Azure provided config features - read configs from KeyVaults, use environment configuration, etc...